### PR TITLE
standarizing to two decimals

### DIFF
--- a/utils/formatNumber.ts
+++ b/utils/formatNumber.ts
@@ -14,7 +14,7 @@ function formatNumber(number: string | number, symbol: string, standard?: boolea
   return new Intl.NumberFormat('en-GB', {
     notation: standard ? 'standard' : 'compact',
     compactDisplay: 'short',
-    minimumFractionDigits: 0,
+    minimumFractionDigits: 2,
     maximumFractionDigits: dictionary[symbol.toUpperCase()] ?? 2
   }).format(parsedNumber);
 }


### PR DESCRIPTION
closes #371 

The idea is to ALWAYS show 2 decimals, except when showing assets, in that case we display these decimals:

    USD: 2,
    DAI: 2,
    USDC: 2,
    WETH: 8,
    WBTC: 8