### PR TITLE
💄 asset-chart: formats date

### DIFF
--- a/components/asset/FloatingPool/FloatingAPRChart/index.tsx
+++ b/components/asset/FloatingPool/FloatingAPRChart/index.tsx
@@ -11,6 +11,7 @@ import getSubgraph from 'utils/getSubgraph';
 import queryRates from 'utils/queryRates';
 
 import { LangKeys } from 'types/Lang';
+import parseTimestamp from 'utils/parseTimestamp';
 
 interface Props {
   market: string | undefined;
@@ -47,7 +48,11 @@ function FloatingAPRChart({ market, networkName }: Props) {
   }, [market, networkName, queryOptions]);
 
   function formatXAxis(tick: any) {
-    return tick.toLocaleString();
+    try {
+      return parseTimestamp(tick.getTime() / 1000); // directly checks if it's a date
+    } catch (error) {
+      return tick;
+    }
   }
 
   useEffect(() => {


### PR DESCRIPTION
## Before
<img width="532" alt="Screen Shot 2022-10-27 at 12 20 19" src="https://user-images.githubusercontent.com/8449567/198330788-ba1c9c25-e90c-491d-b211-3a9cef6e96b1.png">


## After
<img width="570" alt="Screen Shot 2022-10-27 at 12 19 35" src="https://user-images.githubusercontent.com/8449567/198330669-8fd79af8-6ee5-4c45-b96c-15154fd87f11.png">
