### PR TITLE
🐛 Fix hydration problem

### DIFF
--- a/components/Navbar/index.tsx
+++ b/components/Navbar/index.tsx
@@ -17,6 +17,7 @@ import Link from 'next/link';
 import Wallet from 'components/Wallet';
 import SelectNetwork from 'components/SelectNetwork';
 import { allowedChains } from 'utils/client';
+import ClientOnly from 'components/common/ClientOnly';
 const { maxWidth, onlyMobile, onlyDesktop, onlyDesktopFlex } = globals;
 
 const routes = [
@@ -51,62 +52,64 @@ function Navbar() {
   }
 
   return (
-    <Box sx={{ display: 'flex', justifyContent: 'center' }}>
-      <DisclaimerModal />
-      <AppBar position="static" color="transparent" sx={{ maxWidth }}>
-        <Toolbar disableGutters sx={{ padding: '0 0', gap: '8px' }}>
-          <Link href={{ pathname: '/', query }}>
-            <Box mr="10px" sx={{ cursor: 'pointer' }}>
-              <Image
-                src={theme === 'light' ? '/img/logo.svg' : '/img/logo-white.png'}
-                alt="Exactly Logo"
-                layout="fixed"
-                width={103}
-                height={30}
-              />
-            </Box>
-          </Link>
-          {routes.map(({ name, pathname }) => (
-            <Link key={pathname} href={{ pathname, query }}>
-              <Box
-                sx={{
-                  mx: '8px',
-                  py: '4px',
-                  display: onlyDesktop,
-                  cursor: 'pointer',
-                  color: currentPathname === pathname ? 'primary' : 'grey.600',
-                  borderBottom: currentPathname === pathname ? '2px solid' : '2px solid transparent',
-                  ':hover': { borderBottom: '2px solid' },
-                  fontSize: '14px',
-                  fontWeight: 700,
-                }}
-              >
-                {name}
+    <ClientOnly>
+      <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+        <DisclaimerModal />
+        <AppBar position="static" color="transparent" sx={{ maxWidth }}>
+          <Toolbar disableGutters sx={{ padding: '0 0', gap: '8px' }}>
+            <Link href={{ pathname: '/', query }}>
+              <Box mr="10px" sx={{ cursor: 'pointer' }}>
+                <Image
+                  src={theme === 'light' ? '/img/logo.svg' : '/img/logo-white.png'}
+                  alt="Exactly Logo"
+                  layout="fixed"
+                  width={103}
+                  height={30}
+                />
               </Box>
             </Link>
-          ))}
-          <Box display="flex" gap={0.5} ml="auto" flexDirection={{ xs: 'row-reverse', sm: 'row' }}>
-            {isConnected && chain?.id === goerli.id && (
-              <Chip label="Goerli Faucet" onClick={handleFaucetClick} sx={{ my: 'auto', display: onlyDesktopFlex }} />
-            )}
-            {isConnected && <SelectNetwork />}
-            <Wallet />
-          </Box>
-          <IconButton
-            size="small"
-            edge="start"
-            aria-label="menu"
-            sx={{ display: onlyMobile }}
-            onClick={() => setOpenMenu(true)}
-          >
-            <MenuIcon sx={{ color: 'grey.300' }} />
-          </IconButton>
-          <Box display={onlyMobile}>
-            <MobileMenu open={openMenu} handleClose={() => setOpenMenu(false)} />
-          </Box>
-        </Toolbar>
-      </AppBar>
-    </Box>
+            {routes.map(({ name, pathname }) => (
+              <Link key={pathname} href={{ pathname, query }}>
+                <Box
+                  sx={{
+                    mx: '8px',
+                    py: '4px',
+                    display: onlyDesktop,
+                    cursor: 'pointer',
+                    color: currentPathname === pathname ? 'primary' : 'grey.600',
+                    borderBottom: currentPathname === pathname ? '2px solid' : '2px solid transparent',
+                    ':hover': { borderBottom: '2px solid' },
+                    fontSize: '14px',
+                    fontWeight: 700,
+                  }}
+                >
+                  {name}
+                </Box>
+              </Link>
+            ))}
+            <Box display="flex" gap={0.5} ml="auto" flexDirection={{ xs: 'row-reverse', sm: 'row' }}>
+              {isConnected && chain?.id === goerli.id && (
+                <Chip label="Goerli Faucet" onClick={handleFaucetClick} sx={{ my: 'auto', display: onlyDesktopFlex }} />
+              )}
+              {isConnected && <SelectNetwork />}
+              <Wallet />
+            </Box>
+            <IconButton
+              size="small"
+              edge="start"
+              aria-label="menu"
+              sx={{ display: onlyMobile }}
+              onClick={() => setOpenMenu(true)}
+            >
+              <MenuIcon sx={{ color: 'grey.300' }} />
+            </IconButton>
+            <Box display={onlyMobile}>
+              <MobileMenu open={openMenu} handleClose={() => setOpenMenu(false)} />
+            </Box>
+          </Toolbar>
+        </AppBar>
+      </Box>
+    </ClientOnly>
   );
 }
 

--- a/components/common/ClientOnly/index.tsx
+++ b/components/common/ClientOnly/index.tsx
@@ -1,0 +1,16 @@
+import React, { FC, PropsWithChildren } from 'react';
+
+// This component is used to prevent the content from being rendered on the server.
+// More info: https://www.joshwcomeau.com/react/the-perils-of-rehydration
+const ClientOnly: FC<PropsWithChildren> = ({ children, ...delegated }) => {
+  const [hasMounted, setHasMounted] = React.useState(false);
+  React.useEffect(() => {
+    setHasMounted(true);
+  }, []);
+  if (!hasMounted) {
+    return null;
+  }
+  return <div {...delegated}>{children}</div>;
+};
+
+export default ClientOnly;

--- a/components/dashboard/DashboardContent/index.tsx
+++ b/components/dashboard/DashboardContent/index.tsx
@@ -16,6 +16,7 @@ import MobileTabs from 'components/MobileTabs';
 import DashboardMobile from './DashboardMobile';
 import ConnectYourWallet from './ConnectYourWallet';
 import { useTheme } from '@mui/material/styles';
+import ClientOnly from 'components/common/ClientOnly';
 
 const depositTab = {
   label: 'Your Deposits',
@@ -56,32 +57,34 @@ function DashboardContent() {
     [],
   );
 
-  if (!isConnected) {
-    return <ConnectYourWallet />;
-  }
-
   return (
-    <>
-      {!isMobile && ( // display={onlyDesktop} throws an error when used with mui tabs
-        <Grid mt={5}>
-          <DashboardTabs initialTab={allTabs[0].value} allTabs={allTabs} />
-        </Grid>
+    <ClientOnly>
+      {isConnected ? (
+        <>
+          {!isMobile && ( // display={onlyDesktop} throws an error when used with mui tabs
+            <Grid mt={5}>
+              <DashboardTabs initialTab={allTabs[0].value} allTabs={allTabs} />
+            </Grid>
+          )}
+          <Box display={onlyMobile} my={2}>
+            <MobileTabs
+              tabs={[
+                {
+                  title: 'Your Deposits',
+                  content: <DashboardMobile type="deposit" />,
+                },
+                {
+                  title: 'Your Borrows',
+                  content: <DashboardMobile type="borrow" />,
+                },
+              ]}
+            />
+          </Box>
+        </>
+      ) : (
+        <ConnectYourWallet />
       )}
-      <Box display={onlyMobile} my={2}>
-        <MobileTabs
-          tabs={[
-            {
-              title: 'Your Deposits',
-              content: <DashboardMobile type="deposit" />,
-            },
-            {
-              title: 'Your Borrows',
-              content: <DashboardMobile type="borrow" />,
-            },
-          ]}
-        />
-      </Box>
-    </>
+    </ClientOnly>
   );
 }
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -18,14 +18,14 @@ import { wagmi, walletConnectId, web3modal } from 'utils/client';
 import theme, { globals } from 'styles/theme';
 import Footer from 'components/Footer';
 import Navbar from 'components/Navbar';
-import { Grid, NoSsr, useMediaQuery } from '@mui/material';
+import { Grid, useMediaQuery } from '@mui/material';
 
 const { maxWidth } = globals;
 
 export default function App({ Component, pageProps }: AppProps) {
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   return (
-    <NoSsr>
+    <>
       <Head>
         <title>Exactly App - Decentralizing the time value of money</title>
         <meta name="description" content="Exactly App - Decentralizing the time value of money" />
@@ -61,6 +61,6 @@ export default function App({ Component, pageProps }: AppProps) {
           </LangProvider>
         </MUIThemeProvider>
       </ThemeProvider>
-    </NoSsr>
+    </>
   );
 }


### PR DESCRIPTION
I tried using dynamic imports with `SSR: false` and it worked for the hydration error, but there is still present this other error https://sentry.io/organizations/exactly/issues/3836937288/?referrer=slack

The best solution that works for both errors is the `NoSSR` mui component 

--------- Edit ---------

A short explanation of why we have hydration errors:
Next uses hydration to transform the static HTML created at build time into a React application.
The problem is that when we’re using SSR (Server-Side Rendered), it technically renders the page a specific way, and then when the client (the browser) renders things, it expects that the state rendered by the server matches what is on the client side to ensure it knows how to manage its state.

In our case, this error occurs whenever we have conditional rendering depending on the `isConnected` property. That means for the first few moments that a user is on our site, we don't know whether they are connected or not. This is because the HTML file is built at compile-time. Every single user gets an identical copy of that HTML, regardless of whether they're connected or not.

The solution: we need to ensure that the rehydrated app matches the original HTML (having a default state until the component is mounted)

For more info: https://www.joshwcomeau.com/react/the-perils-of-rehydration/
