### PR TITLE
🚸 show maturity date in "best deposit/borrow" market table

### DIFF
--- a/components/markets/MarketsTables/poolTable/index.tsx
+++ b/components/markets/MarketsTables/poolTable/index.tsx
@@ -9,7 +9,7 @@ import TableRow from '@mui/material/TableRow';
 import Typography from '@mui/material/Typography';
 import Grid from '@mui/material/Grid';
 import Button from '@mui/material/Button';
-import { Skeleton, Tooltip } from '@mui/material';
+import { Box, Skeleton, Tooltip } from '@mui/material';
 
 import Image from 'next/image';
 import { useRouter } from 'next/router';
@@ -120,7 +120,7 @@ const PoolTable: FC<PoolTableProps> = ({ isLoading, headers, rows, rateType }) =
                   <TableCell align="left" sx={{ width: '200px' }}>
                     <Typography>{isLoading ? <Skeleton width={80} /> : `$${totalBorrowed}`}</Typography>
                   </TableCell>
-                  <TableCell align="left" sx={{ width: '200px' }}>
+                  <TableCell align="left" sx={{ width: '200px', py: 1 }}>
                     {isLoading ? (
                       <Skeleton width={60} />
                     ) : (
@@ -138,13 +138,20 @@ const PoolTable: FC<PoolTableProps> = ({ isLoading, headers, rows, rateType }) =
                         arrow
                         placement="top"
                       >
-                        <Typography width="fit-content">
-                          {toPercentage(depositAPR && depositAPR > minAPRValue ? depositAPR : undefined)}
-                        </Typography>
+                        <Box display="flex" flexDirection="column" width="fit-content">
+                          <Typography width="fit-content">
+                            {toPercentage(depositAPR && depositAPR > minAPRValue ? depositAPR : undefined)}
+                          </Typography>
+                          {rateType === 'fixed' && (
+                            <Typography width="fit-content" variant="subtitle2" sx={{ color: 'grey.500' }}>
+                              {depositMaturity ? parseTimestamp(depositMaturity, 'MMM DD') : ''}
+                            </Typography>
+                          )}
+                        </Box>
                       </Tooltip>
                     )}
                   </TableCell>
-                  <TableCell align="left" sx={{ width: '200px' }}>
+                  <TableCell align="left" sx={{ width: '200px', py: 1 }}>
                     {isLoading ? (
                       <Skeleton width={60} />
                     ) : (
@@ -162,9 +169,16 @@ const PoolTable: FC<PoolTableProps> = ({ isLoading, headers, rows, rateType }) =
                         arrow
                         placement="top"
                       >
-                        <Typography width="fit-content">
-                          {toPercentage(borrowAPR && borrowAPR > minAPRValue ? borrowAPR : undefined)}
-                        </Typography>
+                        <Box display="flex" flexDirection="column" width="fit-content">
+                          <Typography width="fit-content">
+                            {toPercentage(borrowAPR && borrowAPR > minAPRValue ? borrowAPR : undefined)}
+                          </Typography>
+                          {rateType === 'fixed' && (
+                            <Typography width="fit-content" variant="subtitle2" sx={{ color: 'grey.500' }}>
+                              {borrowMaturity ? parseTimestamp(borrowMaturity, 'MMM DD') : ''}
+                            </Typography>
+                          )}
+                        </Box>
                       </Tooltip>
                     )}
                   </TableCell>

--- a/utils/parseTimestamp.tsx
+++ b/utils/parseTimestamp.tsx
@@ -1,8 +1,8 @@
 import dayjs from 'dayjs';
 
-export default function parseTimestamp(timestamp: string | number) {
+export default function parseTimestamp(timestamp: string | number, format = 'MMM DD, YYYY') {
   if (typeof timestamp === 'string') {
     timestamp = parseInt(timestamp);
   }
-  return dayjs.unix(timestamp).format('MMM DD, YYYY');
+  return dayjs.unix(timestamp).format(format);
 }


### PR DESCRIPTION
closes #785 

<img width="1242" alt="Screen Shot 2023-01-09 at 15 22 53" src="https://user-images.githubusercontent.com/11811232/211380902-fb1e0334-a252-41d8-a836-8d2ffcbcb287.png">
<img width="185" alt="Screen Shot 2023-01-09 at 15 23 29" src="https://user-images.githubusercontent.com/11811232/211380919-09b5e554-eed4-4081-9a15-41eadd81d453.png">
