### PR TITLE
🐛 use `NEXT_PUBLIC_` prefix on sentry env

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -2,10 +2,11 @@ import * as Sentry from '@sentry/nextjs';
 import { ExtraErrorData } from '@sentry/integrations';
 
 const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;
+const SENTRY_ENVIRONMENT = process.env.SENTRY_ENVIRONMENT || process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT;
 
 Sentry.init({
   dsn: SENTRY_DSN,
   tracesSampleRate: 1.0,
   integrations: [new ExtraErrorData({ depth: 5 })],
-  environment: process.env.SENTRY_ENVIRONMENT,
+  environment: SENTRY_ENVIRONMENT,
 });


### PR DESCRIPTION
We are still getting errors reported from https://goerli.exact.ly ([e.g.](https://sentry.io/organizations/exactly/issues/3872595308/?project=6632406&query=is%3Aunresolved&referrer=issue-stream)). 
I suspect this is because the env var is not being exposed to the browser due to not being prefixed with `NEXT_PUBLIC_` ([see](https://nextjs.org/docs/basic-features/environment-variables#exposing-environment-variables-to-the-browser)). 

![image](https://user-images.githubusercontent.com/9066191/212352757-b9f152a1-db7c-438a-9e34-6ca9222cf7ba.png)

![image](https://user-images.githubusercontent.com/9066191/212352690-ce95cb70-ffa2-49d4-b84a-e32f5e3849c9.png)
