### PR TITLE
🐛 Modal: Fix exception caused when starting with `.`

### DIFF
--- a/components/OperationsModal/Info/ModalInfoBorrowLimit.tsx
+++ b/components/OperationsModal/Info/ModalInfoBorrowLimit.tsx
@@ -7,7 +7,6 @@ import AccountDataContext from 'contexts/AccountDataContext';
 
 import formatNumber from 'utils/formatNumber';
 import getBeforeBorrowLimit from 'utils/getBeforeBorrowLimit';
-import { checkPrecision } from 'utils/utils';
 import ModalInfo, { FromTo, Variant } from 'components/common/modal/ModalInfo';
 import { Operation } from 'contexts/ModalStatusContext';
 
@@ -27,8 +26,6 @@ function ModalInfoBorrowLimit({ qty, symbol, operation, variant = 'column' }: Pr
     if (!qty) return Zero;
 
     const { decimals } = accountData[symbol];
-
-    if (!checkPrecision(qty, decimals)) return;
 
     return parseFixed(qty, decimals);
   }, [accountData, symbol, qty]);

--- a/components/OperationsModal/Info/ModalInfoHealthFactor.tsx
+++ b/components/OperationsModal/Info/ModalInfoHealthFactor.tsx
@@ -10,7 +10,6 @@ import getHealthFactorData from 'utils/getHealthFactorData';
 
 import AccountDataContext from 'contexts/AccountDataContext';
 import { Operation } from 'contexts/ModalStatusContext';
-import { checkPrecision } from 'utils/utils';
 
 import ModalInfo, { FromTo, Variant } from 'components/common/modal/ModalInfo';
 
@@ -30,8 +29,6 @@ function ModalInfoHealthFactor({ qty, symbol, operation, variant = 'column' }: P
     if (!qty) return Zero;
 
     const { decimals } = accountData[symbol];
-
-    if (!checkPrecision(qty, decimals)) return;
 
     return parseFixed(qty, decimals);
   }, [accountData, symbol, qty]);

--- a/components/common/modal/ModalInput/index.tsx
+++ b/components/common/modal/ModalInput/index.tsx
@@ -15,7 +15,12 @@ const NumberFormatCustom = React.forwardRef<HTMLInputElement, InputBaseComponent
         {...other}
         getInputRef={ref}
         decimalScale={decimals}
-        onValueChange={({ value }) => onValueChange(value)}
+        onValueChange={({ value }) => {
+          if (value === '.') {
+            return onValueChange('0.');
+          }
+          onValueChange(value);
+        }}
         allowedDecimalSeparators={[',']}
         allowNegative={false}
         defaultValue={0.0}


### PR DESCRIPTION
Closes #806 
- Fix issue
- Remove unnecessary checks which caused some info sections to remain loading on `0.`