### PR TITLE
Android WC: Fix some uncaught exceptions

### DIFF
--- a/hooks/useApprove.ts
+++ b/hooks/useApprove.ts
@@ -9,6 +9,7 @@ import { Operation } from 'contexts/ModalStatusContext';
 import { useWeb3 } from './useWeb3';
 import { useOperationContext } from 'contexts/OperationContext';
 import useAccountData from './useAccountData';
+import handleOperationError from 'utils/handleOperationError';
 
 export default (operation: Operation, contract?: ERC20 | Market, spender?: string) => {
   const { walletAddress } = useWeb3();
@@ -64,11 +65,11 @@ export default (operation: Operation, contract?: ERC20 | Market, spender?: strin
         gasLimit: gasEstimation.mul(parseFixed(String(numbers.gasLimitMultiplier), 18)).div(WeiPerEther),
       });
 
-      return await approveTx.wait();
+      await approveTx.wait();
     } catch (error: any) {
       const isDenied = [ErrorCode.ACTION_REJECTED, ErrorCode.TRANSACTION_REPLACED].includes(error?.code);
 
-      if (!isDenied) captureException(error);
+      if (!isDenied) handleOperationError(error);
 
       setErrorData({
         status: true,

--- a/utils/handleOperationError.ts
+++ b/utils/handleOperationError.ts
@@ -2,13 +2,13 @@ import { ErrorCode } from '@ethersproject/logger';
 import { captureException } from '@sentry/nextjs';
 import ErrorInterface from './ErrorInterface';
 
-export default (error: any) => {
+export default (error: any): string => {
   if (!error?.code) {
     captureException(error);
     return 'There was an error, please try again';
   }
 
-  switch (error?.code) {
+  switch (error.code) {
     case ErrorCode.ACTION_REJECTED:
       return 'Transaction rejected by user';
     case ErrorCode.TRANSACTION_REPLACED:
@@ -58,6 +58,10 @@ export default (error: any) => {
           }
       }
     }
+  }
+
+  if (error.code && error.message) {
+    return error.message;
   }
 
   // if none of the above, report to sentry


### PR DESCRIPTION
- Avoids flooding sentry with known exceptions that were being sent due to being in a different shape
- I couldn't fix the exception produced by rejecting a wallet connect request to connect