### PR TITLE
👷 Preview: skip E2E on drafts PRs

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -1,5 +1,6 @@
 on:
   pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
   workflow_dispatch:
 
 jobs:
@@ -23,6 +24,7 @@ jobs:
       - run: npx unimported
 
   e2e:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
     environment: Test
     needs: check


### PR DESCRIPTION
I found myself disabling E2E tests for some experimental PRs and realized that we probably should be skipping for all drafts, and just run once they become ready. Thoughts?

EDIT:
Tested using this PR.
Draft (only `check` ran, `e2e` was skipped): 
![image](https://user-images.githubusercontent.com/9066191/230116638-c984ffe8-4af3-4b29-8121-ed599f60691b.png)
Clicking on `Ready for Review` re-runned the jobs:
![image](https://user-images.githubusercontent.com/9066191/230116911-83578533-ddac-4835-a565-fdf9db81517f.png)
![image](https://user-images.githubusercontent.com/9066191/230119550-212b3de0-3e8e-4417-89f2-6ff07cc035ab.png)


