### PR TITLE
🩹 add warning when user is trying to deposit all balance

### DIFF
--- a/components/common/modal/ModalAlert/index.tsx
+++ b/components/common/modal/ModalAlert/index.tsx
@@ -35,7 +35,7 @@ const icon: Record<Variant, typeof InfoIcon> = {
   success: SuccessIcon,
 };
 
-function ModalAlert({ variant = 'info', message }: Props) {
+function ModalAlert({ variant = 'error', message }: Props) {
   const { view } = useMarketContext();
   const { pathname: currentPathname } = useRouter();
 

--- a/components/markets/MarketsBasic/index.tsx
+++ b/components/markets/MarketsBasic/index.tsx
@@ -215,7 +215,7 @@ const MarketsBasic: FC = () => {
           <Overview symbol={symbol} operation={operation} qty={qty} option={currentOption || {}} />
         )}
 
-        {errorData?.status && <ModalAlert variant={errorData.variant || 'error'} message={errorData.message} />}
+        {errorData?.status && <ModalAlert variant={errorData.variant} message={errorData.message} />}
 
         <Box mt={1}>
           <Submit symbol={symbol} operation={operation} option={currentOption || {}} qty={qty} errorData={errorData} />

--- a/components/operations/Borrow/index.tsx
+++ b/components/operations/Borrow/index.tsx
@@ -82,7 +82,7 @@ const Borrow: FC = () => {
 
       {errorData?.status && (
         <Grid item mt={1}>
-          <ModalAlert variant={errorData.variant || 'error'} message={errorData.message} />
+          <ModalAlert variant={errorData.variant} message={errorData.message} />
         </Grid>
       )}
 

--- a/components/operations/BorrowAtMaturity/index.tsx
+++ b/components/operations/BorrowAtMaturity/index.tsx
@@ -118,7 +118,7 @@ const BorrowAtMaturity: FC = () => {
 
       {errorData?.status && (
         <Grid item mt={1}>
-          <ModalAlert variant="error" message={errorData.message} />
+          <ModalAlert variant={errorData.variant} message={errorData.message} />
         </Grid>
       )}
 

--- a/components/operations/Deposit/index.tsx
+++ b/components/operations/Deposit/index.tsx
@@ -83,7 +83,7 @@ const Deposit: FC = () => {
 
       {errorData?.status && (
         <Grid item mt={1}>
-          <ModalAlert variant="error" message={errorData.message} />
+          <ModalAlert variant={errorData.variant} message={errorData.message} />
         </Grid>
       )}
 

--- a/components/operations/DepositAtMaturity/index.tsx
+++ b/components/operations/DepositAtMaturity/index.tsx
@@ -108,7 +108,7 @@ const DepositAtMaturity: FC = () => {
       {(errorData?.status || gtMaxYield) && (
         <Grid item mt={1}>
           {gtMaxYield && <ModalAlert variant="warning" message={t('You have reached the maximum yield possible')} />}
-          {errorData?.status && <ModalAlert variant="error" message={errorData.message} />}
+          {errorData?.status && <ModalAlert variant={errorData.variant} message={errorData.message} />}
         </Grid>
       )}
 

--- a/components/operations/Withdraw/index.tsx
+++ b/components/operations/Withdraw/index.tsx
@@ -260,7 +260,7 @@ const Withdraw: FC = () => {
 
       {errorData?.status && (
         <Grid item mt={1}>
-          <ModalAlert variant="error" message={errorData.message} />
+          <ModalAlert variant={errorData.variant} message={errorData.message} />
         </Grid>
       )}
 

--- a/components/operations/WithdrawAtMaturity/index.tsx
+++ b/components/operations/WithdrawAtMaturity/index.tsx
@@ -351,7 +351,7 @@ const WithdrawAtMaturity: FC = () => {
 
       {errorData?.status && (
         <Grid item mt={1}>
-          <ModalAlert variant="error" message={errorData.message} />
+          <ModalAlert variant={errorData.variant} message={errorData.message} />
         </Grid>
       )}
 

--- a/contexts/OperationContext.tsx
+++ b/contexts/OperationContext.tsx
@@ -167,7 +167,7 @@ export function usePreviewTx({
       });
 
       const gas = await previewGasCost(qty).catch((e) => {
-        error = { status: true, message: handleOperationError(e), component: 'gas' };
+        error = { status: true, message: handleOperationError(e), component: 'gas', variant: e.variant };
         return null;
       });
 

--- a/hooks/useDepositAtMaturity.ts
+++ b/hooks/useDepositAtMaturity.ts
@@ -12,6 +12,7 @@ import { useTranslation } from 'react-i18next';
 import { OperationHook } from 'types/OperationHook';
 import useAnalytics from './useAnalytics';
 import { defaultAmount, gasLimitMultiplier } from 'utils/const';
+import { CustomError } from 'types/Error';
 
 type DepositAtMaturity = {
   deposit: () => void;
@@ -92,6 +93,10 @@ export default (): DepositAtMaturity => {
         const gasEstimation = await ETHRouterContract.estimateGas.depositAtMaturity(date, minAmount, {
           value: amount,
         });
+        const gasCost = gasPrice.mul(gasEstimation);
+        if (amount.add(gasCost).gte(parseFixed(walletBalance || '0', 18))) {
+          throw new CustomError(t('Reserve ETH for gas fees.'), 'warning');
+        }
         return gasPrice.mul(gasEstimation);
       }
 
@@ -112,6 +117,7 @@ export default (): DepositAtMaturity => {
       requiresApproval,
       slippage,
       approveEstimateGas,
+      t,
     ],
   );
 

--- a/i18n/es/translation.json
+++ b/i18n/es/translation.json
@@ -258,5 +258,6 @@
   "The lowest fixed borrowing interest APR at current utilization levels for all the Fixed Rate Pools.": "La TNA fija más baja para préstamos en los niveles actuales de utilización para todos los Pools de Tasa Fija.",
   "The fixed interest APR for a deposit up to the optimal deposit size.": "La TNA fija para un depósito hasta el monto de depósito óptimo.",
   "The fixed borrowing interest APR at current utilization level.": "La TNA fija para préstamo en el nivel actual de utilización.",
-  "Make sure to repay your fixed borrows before {{date}} to avoid penalty fees.": "Asegúrese de repagar sus préstamos a tasa fija antes del {{date}} para evitar multas"
+  "Make sure to repay your fixed borrows before {{date}} to avoid penalty fees.": "Asegúrese de repagar sus préstamos a tasa fija antes del {{date}} para evitar multas",
+  "Reserve ETH for gas fees.": "Reserva ETH para el costo de la transacción."
 }

--- a/types/Error.tsx
+++ b/types/Error.tsx
@@ -11,3 +11,11 @@ export type ErrorData =
       component?: string;
       variant?: 'error' | 'warning';
     };
+
+export class CustomError extends Error {
+  public custom = true;
+
+  constructor(message: string, public variant?: 'error' | 'warning') {
+    super(message);
+  }
+}

--- a/utils/handleOperationError.ts
+++ b/utils/handleOperationError.ts
@@ -8,6 +8,9 @@ const defaultErr = i18n.t('There was an error, please try again');
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default (error: any, captureException: typeof sentryCaptureException = sentryCaptureException): string => {
   if (!error?.code) {
+    if (error?.custom) {
+      return error.message;
+    }
     captureException(error);
     return defaultErr;
   }


### PR DESCRIPTION
We attempted to add the `from` address to the preview method, but it still allowed users to deposit all the ETH in their wallets. As a result, we decided to display a warning if the sum of the gas cost and user input exceeds the gas cost.

<img width="493" alt="image" src="https://user-images.githubusercontent.com/11811232/234631063-5fd88764-5f57-4f40-b68a-8f2cae8e79c5.png">