### PR TITLE
🩹 Operations: fix modal failing to estimate approval

### DIFF
--- a/components/operations/Repay/index.tsx
+++ b/components/operations/Repay/index.tsx
@@ -191,7 +191,7 @@ function Repay() {
     async (quantity: string): Promise<BigNumber | undefined> => {
       if (!marketAccount || !walletAddress || !ETHRouterContract || !marketContract || !quantity) return;
 
-      if (requiresApproval) {
+      if (await needsApproval(quantity)) {
         return approveEstimateGas();
       }
 
@@ -221,7 +221,7 @@ function Repay() {
       walletAddress,
       ETHRouterContract,
       marketContract,
-      requiresApproval,
+      needsApproval,
       estimate,
       approveEstimateGas,
       walletBalance,

--- a/components/operations/RepayAtMaturity/index.tsx
+++ b/components/operations/RepayAtMaturity/index.tsx
@@ -161,7 +161,7 @@ const RepayAtMaturity: FC = () => {
     async (quantity: string): Promise<BigNumber | undefined> => {
       if (!marketAccount || !walletAddress || !ETHRouterContract || !marketContract || !date || !quantity) return;
 
-      if (requiresApproval) {
+      if (await needsApproval(quantity)) {
         return approveEstimateGas();
       }
 
@@ -196,7 +196,7 @@ const RepayAtMaturity: FC = () => {
       ETHRouterContract,
       marketContract,
       date,
-      requiresApproval,
+      needsApproval,
       positionAssetsAmount,
       maxAmountToRepay,
       slippage,

--- a/components/operations/Withdraw/index.tsx
+++ b/components/operations/Withdraw/index.tsx
@@ -77,7 +77,7 @@ const Withdraw: FC = () => {
     async (quantity: string): Promise<BigNumber | undefined> => {
       if (!walletAddress || !marketContract || !ETHRouterContract || !marketAccount || !quantity) return;
 
-      if (requiresApproval) {
+      if (await needsApproval(quantity)) {
         return approveEstimateGas();
       }
 
@@ -102,7 +102,7 @@ const Withdraw: FC = () => {
       marketContract,
       ETHRouterContract,
       marketAccount,
-      requiresApproval,
+      needsApproval,
       isMax,
       estimate,
       approveEstimateGas,

--- a/components/operations/WithdrawAtMaturity/index.tsx
+++ b/components/operations/WithdrawAtMaturity/index.tsx
@@ -150,7 +150,7 @@ const WithdrawAtMaturity: FC = () => {
     async (quantity: string): Promise<BigNumber | undefined> => {
       if (!marketAccount || !walletAddress || !marketContract || !ETHRouterContract || !date || !quantity) return;
 
-      if (requiresApproval) {
+      if (await needsApproval(quantity)) {
         return approveEstimateGas();
       }
 
@@ -182,7 +182,7 @@ const WithdrawAtMaturity: FC = () => {
       marketContract,
       ETHRouterContract,
       date,
-      requiresApproval,
+      needsApproval,
       amountToWithdraw,
       minAmountToWithdraw,
       estimate,

--- a/hooks/useBorrow.ts
+++ b/hooks/useBorrow.ts
@@ -72,7 +72,7 @@ export default (): Borrow => {
     async (quantity: string): Promise<BigNumber | undefined> => {
       if (!marketAccount || !walletAddress || !marketContract || !ETHRouterContract || !quantity) return;
 
-      if (requiresApproval) {
+      if (await needsApproval(quantity)) {
         return approveEstimateGas();
       }
 
@@ -90,7 +90,7 @@ export default (): Borrow => {
       );
       return estimate(populated);
     },
-    [marketAccount, walletAddress, marketContract, ETHRouterContract, requiresApproval, estimate, approveEstimateGas],
+    [marketAccount, walletAddress, marketContract, ETHRouterContract, needsApproval, estimate, approveEstimateGas],
   );
 
   const isLoading = useMemo(() => isLoadingOp || approveIsLoading, [isLoadingOp, approveIsLoading]);

--- a/hooks/useBorrowAtMaturity.ts
+++ b/hooks/useBorrowAtMaturity.ts
@@ -87,7 +87,7 @@ export default (): BorrowAtMaturity => {
     async (quantity: string): Promise<BigNumber | undefined> => {
       if (!marketAccount || !walletAddress || !marketContract || !ETHRouterContract || !date || !quantity) return;
 
-      if (requiresApproval) {
+      if (await needsApproval(quantity)) {
         return approveEstimateGas();
       }
 
@@ -116,7 +116,7 @@ export default (): BorrowAtMaturity => {
       marketContract,
       ETHRouterContract,
       date,
-      requiresApproval,
+      needsApproval,
       slippage,
       estimate,
       approveEstimateGas,

--- a/hooks/useDeposit.ts
+++ b/hooks/useDeposit.ts
@@ -66,7 +66,7 @@ export default (): Deposit => {
       )
         return;
 
-      if (requiresApproval) {
+      if (await needsApproval(quantity)) {
         return approveEstimateGas();
       }
 
@@ -92,7 +92,7 @@ export default (): Deposit => {
       marketContract,
       walletBalance,
       marketAccount,
-      requiresApproval,
+      needsApproval,
       estimate,
       approveEstimateGas,
       t,

--- a/hooks/useDepositAtMaturity.ts
+++ b/hooks/useDepositAtMaturity.ts
@@ -82,7 +82,7 @@ export default (): DepositAtMaturity => {
       )
         return;
 
-      if (requiresApproval) {
+      if (await needsApproval(quantity)) {
         return approveEstimateGas();
       }
 
@@ -118,7 +118,7 @@ export default (): DepositAtMaturity => {
       ETHRouterContract,
       date,
       walletBalance,
-      requiresApproval,
+      needsApproval,
       slippage,
       estimate,
       approveEstimateGas,


### PR DESCRIPTION
We were getting `UNPREDICTABLE_GAS_LIMIT` when users were reaching their spending limit