### PR TITLE
🚸 leverager: improve max ratio behaviour

### DIFF
--- a/components/Leverager/Modal/index.tsx
+++ b/components/Leverager/Modal/index.tsx
@@ -83,6 +83,7 @@ function LeveragerModal() {
         sx={{
           padding: { xs: spacing(3, 2, 2), sm: spacing(5, 4, 4) },
           borderTop: tx ? '' : `4px ${palette.mode === 'light' ? 'black' : 'white'} solid`,
+          overflowY: 'auto',
         }}
       >
         {!tx && (

--- a/components/Leverager/MultiplierSlider/index.tsx
+++ b/components/Leverager/MultiplierSlider/index.tsx
@@ -33,6 +33,11 @@ const MultiplierSlider = () => {
     [blockModal, input.borrowSymbol, input.collateralSymbol, netPosition],
   );
 
+  const max = useMemo(
+    () => Math.floor(Math.max(currentLeverageRatio, maxLeverageRatio) * 1e10) / 1e10,
+    [currentLeverageRatio, maxLeverageRatio],
+  );
+
   return (
     <Box display="flex" flexDirection="column" gap={2} sx={{ opacity: disabled ? 0.5 : 1 }}>
       <Box display="flex" justifyContent="space-between" alignItems="center">
@@ -50,7 +55,7 @@ const MultiplierSlider = () => {
         >
           <Typography fontFamily="IBM Plex Mono" fontSize={10}>{`${t(
             'Current',
-          ).toUpperCase()}:${currentLeverageRatio.toFixed(1)}x`}</Typography>
+          ).toUpperCase()}:${currentLeverageRatio.toFixed(2)}x`}</Typography>
         </Box>
       </Box>
       <Box display="flex" justifyItems="space-between" alignItems="center" gap={2}>
@@ -62,9 +67,9 @@ const MultiplierSlider = () => {
           defaultValue={currentLeverageRatio}
           valueLabelDisplay="on"
           min={minLeverageRatio}
-          max={maxLeverageRatio}
-          step={0.1}
-          valueLabelFormat={(value) => `${value.toFixed(1)}x`}
+          max={max}
+          step={0.01}
+          valueLabelFormat={(value) => `${value.toFixed(2)}x`}
           disabled={disabled}
           sx={{
             height: 4,

--- a/components/Leverager/Operation/index.tsx
+++ b/components/Leverager/Operation/index.tsx
@@ -29,7 +29,6 @@ const Operation = () => {
     disabledSubmit,
     isOverLeveraged,
     isPriceImpactAboveThreshold,
-    blockModal,
   } = useLeveragerContext();
 
   return (
@@ -88,12 +87,7 @@ const Operation = () => {
       </ModalBox>
       {errorData?.status && <ModalAlert message={errorData.message} variant={errorData.variant} />}
       {isOverLeveraged && (
-        <ModalAlert
-          message={`${t('You are currently over leveraged with the selected markets.')} ${
-            blockModal ? '' : t('You will only be able to deleverage.')
-          }`}
-          variant="info"
-        />
+        <ModalAlert message={t('You are currently over leveraged with the selected markets.')} variant="info" />
       )}
       {isPriceImpactAboveThreshold && (
         <ModalAlert

--- a/components/Leverager/Summary/index.tsx
+++ b/components/Leverager/Summary/index.tsx
@@ -110,7 +110,7 @@ const Summary = () => {
       },
       {
         label: t('Leverage'),
-        value: <Typography variant="h6">{input.leverageRatio.toFixed(1)}x</Typography>,
+        value: <Typography variant="h6">{input.leverageRatio.toFixed(2)}x</Typography>,
       },
       {
         label: t('Loop APR'),

--- a/components/MobileMenu/index.tsx
+++ b/components/MobileMenu/index.tsx
@@ -21,7 +21,7 @@ import AccountBalanceWalletIcon from '@mui/icons-material/AccountBalanceWallet';
 import RepeatRoundedIcon from '@mui/icons-material/RepeatRounded';
 import BarChartRoundedIcon from '@mui/icons-material/BarChartRounded';
 import MovingSharpIcon from '@mui/icons-material/MovingSharp';
-import { optimism } from 'wagmi/chains';
+import { mainnet, optimism } from 'wagmi/chains';
 import { useWeb3 } from 'hooks/useWeb3';
 import SecondaryChain from 'components/SecondaryChain';
 import RewardsModal from 'components/RewardsModal';
@@ -38,6 +38,7 @@ function MobileMenu({ open, handleClose }: Props) {
   const date = new Date();
   const { chain } = useWeb3();
   const isOPMainnet = chain?.id === optimism.id;
+  const isEthereum = chain?.id === mainnet.id;
   const [openRewardsModal, setOpenRewardsModal] = useState(false);
 
   const headers = [
@@ -126,11 +127,13 @@ function MobileMenu({ open, handleClose }: Props) {
               ))}
             </Box>
             <Divider sx={{ my: 1.5 }} />
-            <RewardsModal
-              isOpen={openRewardsModal}
-              open={() => setOpenRewardsModal(true)}
-              close={() => setOpenRewardsModal(false)}
-            />
+            {!isEthereum && (
+              <RewardsModal
+                isOpen={openRewardsModal}
+                open={() => setOpenRewardsModal(true)}
+                close={() => setOpenRewardsModal(false)}
+              />
+            )}
             <Divider sx={{ my: 1.5 }} />
             <Typography fontFamily="fontFamilyMonospaced" fontSize={14} color="figma.grey.500" fontWeight={600}>
               {t('Links')}

--- a/components/Navbar/index.tsx
+++ b/components/Navbar/index.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
 import { setContext, setUser } from '@sentry/nextjs';
-import { useBlockNumber, useConfig } from 'wagmi';
+import { mainnet, useBlockNumber, useConfig } from 'wagmi';
 import { optimism, goerli } from 'wagmi/chains';
 import Image from 'next/image';
 import useRouter from 'hooks/useRouter';
@@ -92,6 +92,7 @@ function Navbar() {
   }, [currentPathname, view, palette.markets.advanced, palette.markets.simple]);
 
   const isOPMainnet = chain?.id === optimism.id;
+  const isEthereum = chain?.id === mainnet.id;
 
   const routes: {
     pathname: string;
@@ -203,7 +204,7 @@ function Navbar() {
                 open={() => setOpenStakingModal(true)}
                 close={() => setOpenStakingModal(false)}
               />
-              {!isMobile && (
+              {!isMobile && !isEthereum && (
                 <RewardsModal
                   isOpen={openRewardsModal}
                   open={() => setOpenRewardsModal(true)}

--- a/i18n/es/translation.json
+++ b/i18n/es/translation.json
@@ -363,8 +363,6 @@
   "All Strategies": "Estrategias",
   "Take control of your investments with strategies that balance risk and reward for long-term success.": "Toma control de tus inversiones con estrategias que equilibren el riesgo y la recompensa para el éxito a largo plazo.",
   "You are currently over leveraged with the selected markets.": "Actualmente estás sobre apalancado con los mercados seleccionados.",
-  "You will only be able to deleverage.": "Sólo podrás desapalancar.",
-  "You need to deposit more than {{value}} {{symbol}}.": "Necesitas depositar más de {{value}} {{symbol}}.",
   "The APR displayed comes from the Lido API.": "La TNA proviene de la API de Lido.",
   "Price impact is above {{ threshold }}, operation is too risky.": "El impacto en el precio está por encima de {{ threshold }}, la operación es demasiado riesgosa.",
   "You have no voting power in your connected wallet.": "No tienes poder de voto en tu billetera conectada.",


### PR DESCRIPTION
- Include the current ratio in the slider range
- Decrease the slider step from 0.1 to 0.01
- Change the target health factor to `min(currentHF, marketsMinHF)` for the preview call
- Add overflow-y to modal
- Remove the warning "You need to deposit more than..."
- Remove the reward button for Ethereum Mainnet