### PR TITLE
🩹 Package

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,37 +2,44 @@ import { withSentryConfig } from '@sentry/nextjs';
 
 const DISABLE_SENTRY_PLUGIN = JSON.parse(process.env.DISABLE_SENTRY_PLUGIN ?? 'false');
 
-export default withSentryConfig({
-  reactStrictMode: true,
-  productionBrowserSourceMaps: true,
-  sentry: {
-    widenClientFileUpload: true,
-    hideSourceMaps: false,
+export default withSentryConfig(
+  {
+    reactStrictMode: true,
+    productionBrowserSourceMaps: true,
+    redirects: () => [
+      { source: '/markets', destination: '/', permanent: true },
+      { source: '/assets/:symbol*', destination: '/:symbol*', permanent: true },
+    ],
+
+    headers: () => [
+      {
+        source: '/:path*',
+        headers: [
+          { key: 'X-DNS-Prefetch-Control', value: 'on' },
+          { key: 'X-XSS-Protection', value: '1; mode=block' },
+          { key: 'Content-Security-Policy', value: 'frame-ancestors https://app.safe.global' },
+          { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=(), interest-cohort=()' },
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+          { key: 'Referrer-Policy', value: 'strict-origin' },
+          { key: 'Access-Control-Allow-Origin', value: '*' },
+          { key: 'Access-Control-Allow-Methods', value: 'GET' },
+          { key: 'Access-Control-Allow-Headers', value: 'X-Requested-With, content-type, Authorization' },
+        ],
+      },
+    ],
+
+    images: { unoptimized: true },
+  },
+  {
+    silent: true,
+    org: 'exactly',
+    project: 'webapp',
+  },
+  {
     disableServerWebpackPlugin: DISABLE_SENTRY_PLUGIN,
     disableClientWebpackPlugin: DISABLE_SENTRY_PLUGIN,
+    widenClientFileUpload: true,
+    hideSourceMaps: true,
+    disableLogger: true,
   },
-
-  redirects: () => [
-    { source: '/markets', destination: '/', permanent: true },
-    { source: '/assets/:symbol*', destination: '/:symbol*', permanent: true },
-  ],
-
-  headers: () => [
-    {
-      source: '/:path*',
-      headers: [
-        { key: 'X-DNS-Prefetch-Control', value: 'on' },
-        { key: 'X-XSS-Protection', value: '1; mode=block' },
-        { key: 'Content-Security-Policy', value: 'frame-ancestors https://app.safe.global' },
-        { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=(), interest-cohort=()' },
-        { key: 'X-Content-Type-Options', value: 'nosniff' },
-        { key: 'Referrer-Policy', value: 'strict-origin' },
-        { key: 'Access-Control-Allow-Origin', value: '*' },
-        { key: 'Access-Control-Allow-Methods', value: 'GET' },
-        { key: 'Access-Control-Allow-Headers', value: 'X-Requested-With, content-type, Authorization' },
-      ],
-    },
-  ],
-
-  images: { unoptimized: true },
-});
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@mui/icons-material": "^5.14.3",
         "@mui/lab": "^5.0.0-alpha.138",
         "@mui/material": "^5.14.3",
-        "@sentry/browser": "^7.61.1",
         "@sentry/integrations": "^7.61.1",
         "@sentry/nextjs": "^7.61.1",
         "@socket.tech/plugin": "^1.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18275,6 +18275,126 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "13.4.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.12.tgz",
+      "integrity": "sha512-WRvH7RxgRHlC1yb5oG0ZLx8F7uci9AivM5/HGGv9ZyG2Als8Ij64GC3d+mQ5sJhWjusyU6T6V1WKTUoTmOB0zQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "13.4.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.12.tgz",
+      "integrity": "sha512-YEKracAWuxp54tKiAvvq73PUs9lok57cc8meYRibTWe/VdPB2vLgkTVWFcw31YDuRXdEhdX0fWS6Q+ESBhnEig==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "13.4.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.12.tgz",
+      "integrity": "sha512-LhJR7/RAjdHJ2Isl2pgc/JaoxNk0KtBgkVpiDJPVExVWA1c6gzY57+3zWuxuyWzTG+fhLZo2Y80pLXgIJv7g3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "13.4.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.12.tgz",
+      "integrity": "sha512-1DWLL/B9nBNiQRng+1aqs3OaZcxC16Nf+mOnpcrZZSdyKHek3WQh6j/fkbukObgNGwmCoVevLUa/p3UFTTqgqg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "13.4.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.12.tgz",
+      "integrity": "sha512-kEAJmgYFhp0VL+eRWmUkVxLVunn7oL9Mdue/FS8yzRBVj7Z0AnIrHpTIeIUl1bbdQq1VaoOztnKicAjfkLTRCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "13.4.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.12.tgz",
+      "integrity": "sha512-GMLuL/loR6yIIRTnPRY6UGbLL9MBdw2anxkOnANxvLvsml4F0HNIgvnU3Ej4BjbqMTNjD4hcPFdlEow4XHPdZA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "13.4.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.12.tgz",
+      "integrity": "sha512-PhgNqN2Vnkm7XaMdRmmX0ZSwZXQAtamBVSa9A/V1dfKQCV1rjIZeiy/dbBnVYGdj63ANfsOR/30XpxP71W0eww==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "13.4.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.12.tgz",
+      "integrity": "sha512-Z+56e/Ljt0bUs+T+jPjhFyxYBcdY2RIq9ELFU+qAMQMteHo7ymbV7CKmlcX59RI9C4YzN8PgMgLyAoi916b5HA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@mui/icons-material": "^5.14.3",
     "@mui/lab": "^5.0.0-alpha.138",
     "@mui/material": "^5.14.3",
-    "@sentry/browser": "^7.61.1",
     "@sentry/integrations": "^7.61.1",
     "@sentry/nextjs": "^7.61.1",
     "@socket.tech/plugin": "^1.2.1",

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -1,4 +1,4 @@
-import { init, Replay } from '@sentry/browser';
+import { init, Replay } from '@sentry/nextjs';
 import { ExtraErrorData } from '@sentry/integrations';
 import { beforeSend } from './utils/sentry';
 
@@ -10,6 +10,7 @@ init({
   environment: SENTRY_ENVIRONMENT,
   tracesSampleRate: 1.0,
   replaysOnErrorSampleRate: 1.0,
-  integrations: [new ExtraErrorData({ depth: 5 }), Replay && new Replay()].filter(Boolean),
+  replaysSessionSampleRate: 0.1,
+  integrations: [new ExtraErrorData({ depth: 5 }), new Replay()],
   beforeSend,
 });

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -1,1 +1,8 @@
-import './sentry.client.config';
+import { init } from '@sentry/nextjs';
+
+const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;
+
+init({
+  dsn: SENTRY_DSN,
+  tracesSampleRate: 1,
+});

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -1,1 +1,1 @@
-import './sentry.client.config';
+import './sentry.edge.config';


### PR DESCRIPTION
This re-adds the swc deps to the package-lock.json. Though running `npm i` just removes them anyway... `¯\_(ツ)_/¯`
![image](https://github.com/exactly/app/assets/9066191/8c1adebf-0cc6-4a4f-95bb-ad74d7fe1586)

I had to update the sentry config as the DEV server was spamming this. I used their wizard to setup. I followed this past [issue](https://github.com/getsentry/sentry-javascript/issues/8361) that suggests that `init` may not have been called correctly.
![image](https://github.com/exactly/app/assets/9066191/359edf71-8712-4e08-8aa9-17d65da25c58)
