### PR TITLE
✨ E2E Report publish

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -1,11 +1,11 @@
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
-  workflow_dispatch:
+    types: [opened, reopened, synchronize, ready_for_review, closed]
 
 jobs:
   check:
     runs-on: ubuntu-latest
+    if: ${{ contains('opened reopened synchronize ready_for_review', github.event.action) && !github.event.pull_request.merged }}
     environment: Preview
     env:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -25,8 +25,8 @@ jobs:
 
   e2e:
     needs: [check]
-    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-    timeout-minutes: 60
+    if: ${{ !github.event.pull_request.draft && github.event.action != 'closed' }}
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     environment: Test
     env:
@@ -66,7 +66,7 @@ jobs:
 
   e2e-report:
     needs: [e2e]
-    if: ${{ always() && needs.e2e.result == 'success' }}
+    if: ${{ !cancelled() && !github.event.pull_request.draft && !github.event.pull_request.merged }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -81,6 +81,22 @@ jobs:
       - run: npx playwright merge-reports --reporter html ./blob-reports
       - uses: actions/upload-artifact@v3
         with:
-          name: html-report--attempt-${{ github.run_attempt }}
+          name: html-report
           path: playwright-report
           retention-days: 30
+
+  e2e-report-publish:
+    needs: [e2e-report]
+    if: ${{ always() && github.event.action == 'closed' && github.event.pull_request.merged }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: html-report
+          path: html-report
+      - uses: cloudflare/pages-action@v1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: 569f3c4008862b4cc595f409db748f41
+          projectName: app-test
+          directory: html-report

--- a/e2e/common/app.ts
+++ b/e2e/common/app.ts
@@ -2,16 +2,14 @@ import { CommonTest } from './types';
 
 export default function ({ page }: CommonTest) {
   const reload = async () => {
-    await new Promise((r) => setTimeout(r, 15_000));
     await page.reload({ waitUntil: 'domcontentloaded' });
-    await new Promise((r) => setTimeout(r, 30_000));
     await page.waitForFunction(
       () => {
         return document.querySelectorAll('.MuiSkeleton-root').length === 0;
       },
       null,
       {
-        timeout: 15_000,
+        timeout: 30_000,
         polling: 1_000,
       },
     );

--- a/e2e/components/navbar.ts
+++ b/e2e/components/navbar.ts
@@ -6,14 +6,14 @@ export default function (page: Page) {
   const goTo = async (path: Path) => {
     await page.getByTestId(`navbar-link-${path}`).click();
     await page.waitForURL(`**/${path}`, { timeout: 15_000 });
-    await new Promise((resolve) => setTimeout(resolve, 30_000));
+    await page.waitForTimeout(1_000);
     await page.waitForFunction(
       () => {
         return document.querySelectorAll('.MuiSkeleton-root').length === 0;
       },
       null,
       {
-        timeout: 15_000,
+        timeout: 30_000,
         polling: 1_000,
       },
     );

--- a/hooks/useAccountData.ts
+++ b/hooks/useAccountData.ts
@@ -35,7 +35,7 @@ function useAccountData(
   const marketAccount = useMemo(() => (symbol ? getMarketAccount(symbol) : undefined), [symbol, getMarketAccount]);
 
   const refreshAccountData = useCallback(
-    async (delay = 2500) =>
+    async (delay = 250) =>
       new Promise<void>((r) =>
         setTimeout(
           () =>

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,7 +8,7 @@ const config: PlaywrightTestConfig = {
   testMatch: [/.*spec\.ts/],
   timeout: 180_000,
   expect: {
-    timeout: 60_000,
+    timeout: 30_000,
   },
   fullyParallel: true,
   forbidOnly: !!process.env.CI,

--- a/utils/client.ts
+++ b/utils/client.ts
@@ -1,5 +1,5 @@
 import { EthereumClient, w3mConnectors, w3mProvider } from '@web3modal/ethereum';
-import { createConfig, configureChains, ChainProviderFn, Chain } from 'wagmi';
+import { createConfig, configureChains, ChainProviderFn, Chain, createStorage } from 'wagmi';
 import { InjectedConnector } from 'wagmi/connectors/injected';
 import * as wagmiChains from 'wagmi/chains';
 import { jsonRpcProvider } from 'wagmi/providers/jsonRpc';
@@ -43,6 +43,12 @@ const providers: ChainProviderFn<Chain>[] = isE2E
 
 const { chains, publicClient } = configureChains<Chain>(sortedChains, providers);
 
+const noopStorage = {
+  getItem: () => '',
+  setItem: () => null,
+  removeItem: () => null,
+};
+
 export const wagmi = createConfig({
   connectors: [
     ...(isE2E
@@ -50,6 +56,7 @@ export const wagmi = createConfig({
       : [...w3mConnectors({ projectId: walletConnectId, chains }), new SafeConnector({ chains })]),
   ],
   publicClient,
+  ...(isE2E ? { storage: createStorage({ storage: noopStorage }) } : {}),
 });
 
 export const web3modal = new EthereumClient(wagmi, chains);


### PR DESCRIPTION
Closes #1207

This hosts the report from the E2E suite run on CF pages: https://app-tests.exact.ly (tbd)

This had to be added to the same previewer workflow as it required artifacts generated by other jobs. They can be easily obtained through the github/artifacts action, which can _only_ be used with same workflow files.

Also:
- Remove busy waitings from tests. Just left a minor 1s wait when interacting with the navbar.
