### PR TITLE
🐛 get exa: get permit domain version from asset contract

### DIFF
--- a/hooks/useContractVersion.ts
+++ b/hooks/useContractVersion.ts
@@ -1,0 +1,32 @@
+import { Address } from 'viem';
+import { useCallback } from 'react';
+import { usePublicClient } from 'wagmi';
+
+export default function useContractVersion() {
+  const publicClient = usePublicClient();
+
+  return useCallback(
+    async (address: Address) => {
+      try {
+        const version = await publicClient.readContract({
+          address,
+          abi: [
+            {
+              inputs: [],
+              name: 'version',
+              outputs: [{ internalType: 'string', name: '', type: 'string' }],
+              stateMutability: 'pure',
+              type: 'function',
+            },
+          ],
+          functionName: 'version',
+        });
+
+        return version;
+      } catch (e: unknown) {
+        return '1';
+      }
+    },
+    [publicClient],
+  );
+}


### PR DESCRIPTION
fixes issues with “Get EXA” paying with USDC (native).
I checked the flow paying with
ETH :white_check_mark:
USDC.e (Permit2 flow) :white_check_mark:
OP (Permit flow) :white_check_mark:
USDC native (Permit flow) :x:

The issue only happens with USDC native, basically there’s an error verifying the signature.
simulation: https://dashboard.tenderly.co/exactly/exactly/simulator/e60aef1a-0b07-4d72-bd65-2691700d47e5

I’ve been researching and the issue seems to be that we’re always signing permits with domain.version set to "1" . And we need to set "2" for native USDC (https://forum.moralis.io/t/invalid-signature-error-in-erc20permit-eip2612/19513/10).

with this change we fetch the domain version from the contract if it exists, or we use `"1"` as fallback