### PR TITLE
🚸 strategies: add permalink for get-exa modal

### DIFF
--- a/components/GetEXA/ModalWrapper.tsx
+++ b/components/GetEXA/ModalWrapper.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 
 import Link from 'next/link';
 import CloseIcon from '@mui/icons-material/Close';
@@ -9,15 +9,23 @@ import GetEXA from '.';
 import { useModal } from '../../contexts/ModalContext';
 import { GetEXAProvider } from 'contexts/GetEXAContext';
 import { track } from 'utils/mixpanel';
+import { useRouter } from 'next/router';
 
 export default function ModalWrapper() {
   const { isOpen, close } = useModal('get-exa');
   const { t } = useTranslation();
+  const { push } = useRouter();
+
+  const handleClose = useCallback(() => {
+    close();
+    push('/strategies', undefined, { shallow: true });
+  }, [close, push]);
+
   if (!isOpen) return null;
   return (
     <Drawer
       open={isOpen}
-      onClose={close}
+      onClose={handleClose}
       SlideProps={{
         appear: true,
         direction: 'right',
@@ -28,7 +36,7 @@ export default function ModalWrapper() {
         },
       }}
     >
-      <IconButton onClick={close} sx={{ position: 'absolute', right: 8, top: 8 }}>
+      <IconButton onClick={handleClose} sx={{ position: 'absolute', right: 8, top: 8 }}>
         <CloseIcon />
       </IconButton>
       <Box maxWidth={576} paddingX={6} paddingY={7}>

--- a/pages/strategies/[[...slug]].tsx
+++ b/pages/strategies/[[...slug]].tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, Fragment } from 'react';
+import React, { useMemo, Fragment, useEffect } from 'react';
 import type { NextPage } from 'next';
 import { Box, Button, Divider, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
@@ -21,15 +21,27 @@ import { useVELOPoolAPR } from 'hooks/useVELO';
 import { useExtraDepositAPR } from 'hooks/useExtra';
 import { useWeb3 } from 'hooks/useWeb3';
 import FeaturedStrategies from 'components/strategies/FeaturedStrategies';
-import { useModal } from '../contexts/ModalContext';
+import { useModal } from 'contexts/ModalContext';
 import { track } from 'utils/mixpanel';
 
 const Strategies: NextPage = () => {
   const { t } = useTranslation();
-  const { query } = useRouter();
+  const { query, push } = useRouter();
   const { startLeverager } = useStartLeverager();
   const { startDebtManager } = useStartDebtManagerButton();
-  const { open: openGetEXA } = useModal('get-exa');
+  const { open: openGetEXA, close: closeGetEXA } = useModal('get-exa');
+  const isGetEXAPath = query.slug?.[0] === 'get-exa';
+
+  useEffect(
+    function pushRouteChange() {
+      if (isGetEXAPath) {
+        openGetEXA();
+        return;
+      }
+      closeGetEXA();
+    },
+    [closeGetEXA, isGetEXAPath, openGetEXA],
+  );
 
   const { chain } = useWeb3();
 
@@ -304,6 +316,7 @@ const Strategies: NextPage = () => {
               variant="contained"
               onClick={() => {
                 openGetEXA();
+                push('/strategies/get-exa', undefined, { shallow: true });
                 track('Button Clicked', {
                   location: 'Strategies',
                   name: 'get exa',


### PR DESCRIPTION
Now, when opening Get EXA modal from strategies page, the url will change to /strategies/get-exa , so users can share the link and get directly to the modal.