### PR TITLE
💄 market: adjust dropdown button width

### DIFF
--- a/components/DropdownMenu/index.tsx
+++ b/components/DropdownMenu/index.tsx
@@ -78,7 +78,7 @@ const DropdownMenu = <T,>({
         aria-haspopup="true"
         aria-expanded={open ? 'true' : undefined}
         onClick={onClick || handleClick}
-        sx={{ borderRadius: '16px', p: 1, ml: -1, ...buttonSx }}
+        sx={{ borderRadius: '16px', p: 1, ml: -1, minWidth: 'fit-content', ...buttonSx }}
         data-testid={testId}
         disabled={disabled}
       >


### PR DESCRIPTION
Before:
<img width="169" alt="image" src="https://github.com/user-attachments/assets/36cd9962-317e-4a8d-a25f-7879dfc73ad1">

After:
<img width="191" alt="image" src="https://github.com/user-attachments/assets/1eaaa50b-9a3b-443c-9986-3e01f60026b3">
